### PR TITLE
Feat/api

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# Ignore build artifacts
+build/
+*.o
+*.out
+*.exe
+*.a
+*.so
+*.log
+*.tmp
+
+# Ignore local configurations
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+
+# Ignore IDE/editor-specific files
+.vscode/
+.idea/
+*.swp
+*.swo
+*.user
+*.workspace
+*.project
+
+# Ignore version control metadata
+.git/
+.gitignore
+
+# Ignore Docker-related files that aren't needed inside the image
+Dockerfile
+.dockerignore
+
+# Ignore temporary files
+*.tmp
+*.bak
+*.old
+*.~*
+
+# Ignore files in the data directory (if you don't want to include uploaded files in the image)
+data/*
+!data/.gitkeep

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ cmake_minimum_required(VERSION 3.14)
 # Set the project name
 project(file_converter)
 
-# Set the C++ standard to 14 for the project
-set(CMAKE_CXX_STANDARD 14)
+# Set the C++ standard to 17 for the project
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # Ensure CMake creates compile_commands.json for development tools
@@ -23,6 +23,15 @@ include_directories(${GTEST_INCLUDE_DIRS})
 include_directories(include)
 include_directories(include/formatters)
 include_directories(src)
+
+# Conditionally include third party libraries depending on path
+if(APPLE)
+    # macOS
+    include_directories(/opt/homebrew/include)
+elseif(UNIX)
+    # Linux
+    include_directories(/usr/local/include)
+endif()
 
 # Source files for the converter library
 set(CONVERTER_SOURCES
@@ -45,6 +54,10 @@ target_link_libraries(converter_lib ${OpenCV_LIBS})
 # Add executable target for the main application
 add_executable(file_converter src/main.cpp)
 target_link_libraries(file_converter converter_lib)
+
+# Add executable target for the api application
+add_executable(api_service api/api_main.cpp api/api_handler.cpp)
+target_link_libraries(api_service converter_lib)
 
 # Add test executable
 add_executable(runTests test/test_cli.cpp)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:latest
+
+# Install necessary tools and libraries
+RUN apk add --no-cache \
+    build-base \
+    cmake \
+    g++ \
+    opencv-dev \
+    git \
+    python3 \
+    boost-dev \
+    zlib-dev \
+    openssl-dev \
+    asio-dev
+
+# Install Google Test
+RUN git clone https://github.com/google/googletest.git /tmp/googletest \
+    && cd /tmp/googletest \
+    && cmake -S . -B build \
+    && cmake --build build \
+    && cmake --install build \
+    && rm -rf /tmp/googletest
+
+# Install Crow web framework
+RUN git clone https://github.com/CrowCpp/Crow.git /tmp/crow \
+    && cd /tmp/crow \
+    && mkdir build \
+    && cd build \
+    && cmake .. \
+    && make install \
+    && rm -rf /tmp/crow
+
+# Set working directory
+WORKDIR /app
+
+# Copy project files into the container
+COPY . .
+
+# Build the project
+RUN mkdir build && cd build && cmake .. && make
+
+# Expose the server port
+EXPOSE 18080
+
+# Set the default command to run the server
+CMD ["./build/api_service"]

--- a/api/api_handler.cpp
+++ b/api/api_handler.cpp
@@ -1,0 +1,111 @@
+#include "api_handler.h"
+#include "converter.h"
+#include "fileformat.h"
+#include "utils.h"
+#include <filesystem>
+#include <fstream>
+
+void APIHandler::startServer(int port) {
+  crow::SimpleApp app;
+
+  // Ensure the `data` folder exists in the project's root directory
+  std::filesystem::create_directory("./data");
+
+  // Endpoint to check server status
+  CROW_ROUTE(app, "/status")([]() { return "Filely API is running"; });
+
+  // Endpoint to convert files
+  CROW_ROUTE(app, "/convert")
+      .methods(crow::HTTPMethod::POST)([](const crow::request &req) {
+        try {
+          // Parse multipart message from request
+          crow::multipart::message msg(req);
+
+          // Extract file part by name
+          auto filePart = msg.get_part_by_name("file");
+          if (filePart.body.empty()) {
+            return crow::response(400, "No file part found or file is empty.");
+          }
+
+          // Retrieve the filename from the headers
+          auto contentDisposition =
+              filePart.get_header_object("Content-Disposition");
+          std::string fileName = contentDisposition.params["filename"];
+          if (fileName.empty()) {
+            fileName = "uploaded_file"; // Fallback to a default name
+          }
+
+          // Get the filename without the extension (.jpeg, .png, etc)
+          std::filesystem::path filePath(fileName);
+          std::string fileNameWithoutExtension = filePath.stem().string();
+
+          char *fileType = req.url_params.get("type");
+          // Get the file type to convert to from query params
+          if (!fileType) {
+            return crow::response(400,
+                                  "Must provide a file type to convert to");
+          }
+
+          // Save the file to the `data` folder
+          std::string inputPath = "./data/" + fileName;
+          std::string outputPath =
+              "./data/" + fileNameWithoutExtension + "." + fileType;
+          std::ofstream outFile(inputPath, std::ios::binary);
+          outFile.write(filePart.body.data(), filePart.body.size());
+          outFile.close();
+
+          // Conversion logic
+          std::unique_ptr<FileFormat> inputFormat(getFileFormat(inputPath));
+          std::unique_ptr<FileFormat> outputFormat(
+              getFormatFromString(fileType));
+
+          Converter converter(inputPath, outputPath, inputFormat.get(),
+                              outputFormat.get());
+
+          converter.convert();
+
+          return crow::response(200, "File saved to data folder");
+        } catch (const std::exception &e) {
+          std::cerr << "Exception occurred: " << e.what() << std::endl;
+          return crow::response(500, "Unexpected error occurred: ");
+        }
+      });
+
+  // Endpoint to download files
+  CROW_ROUTE(app, "/download")
+      .methods(crow::HTTPMethod::GET)([](const crow::request &req) {
+        try {
+          // Extract the filename from query parameters
+          char *fileName = req.url_params.get("file");
+          if (!fileName) {
+            return crow::response(400, "Missing 'file' query parameter.");
+          }
+
+          // Build the file path
+          std::string filePath = "./data/" + std::string(fileName);
+
+          // Check if the file exists
+          if (!std::filesystem::exists(filePath)) {
+            return crow::response(404, "File not found: " + filePath);
+          }
+
+          // Read the file content
+          std::ifstream inFile(filePath, std::ios::binary);
+          std::ostringstream fileContent;
+          fileContent << inFile.rdbuf();
+          inFile.close();
+
+          // Serve the file as a downloadable response
+          crow::response res(fileContent.str());
+          res.add_header("Content-Disposition",
+                         "attachment; filename=" + std::string(fileName));
+          res.add_header("Content-Type", "application/octet-stream");
+          return res;
+        } catch (const std::exception &e) {
+          return crow::response(500, "Unexpected error occurred: " +
+                                         std::string(e.what()));
+        }
+      });
+
+  app.port(port).multithreaded().run();
+}

--- a/api/api_handler.cpp
+++ b/api/api_handler.cpp
@@ -40,68 +40,51 @@ void APIHandler::startServer(int port) {
           std::string fileNameWithoutExtension = filePath.stem().string();
 
           char *fileType = req.url_params.get("type");
-          // Get the file type to convert to from query params
           if (!fileType) {
             return crow::response(400,
                                   "Must provide a file type to convert to");
           }
 
-          // Save the file to the `data` folder
-          std::string inputPath = "./data/" + fileName;
-          std::string outputPath =
-              "./data/" + fileNameWithoutExtension + "." + fileType;
-          std::ofstream outFile(inputPath, std::ios::binary);
+          // Create temporary paths for processing
+          std::string tempInputPath = "./data/temp_" + fileName;
+          std::string tempOutputPath = "./data/temp_" +
+                                       fileNameWithoutExtension + "." +
+                                       std::string(fileType);
+
+          // Save the input file temporarily
+          std::ofstream outFile(tempInputPath, std::ios::binary);
           outFile.write(filePart.body.data(), filePart.body.size());
           outFile.close();
 
           // Conversion logic
-          std::unique_ptr<FileFormat> inputFormat(getFileFormat(inputPath));
+          std::unique_ptr<FileFormat> inputFormat(getFileFormat(tempInputPath));
           std::unique_ptr<FileFormat> outputFormat(
               getFormatFromString(fileType));
 
-          Converter converter(inputPath, outputPath, inputFormat.get(),
+          Converter converter(tempInputPath, tempOutputPath, inputFormat.get(),
                               outputFormat.get());
-
           converter.convert();
 
-          return crow::response(200, "File saved to data folder");
-        } catch (const std::exception &e) {
-          std::cerr << "Exception occurred: " << e.what() << std::endl;
-          return crow::response(500, "Unexpected error occurred: ");
-        }
-      });
+          // Read the converted file
+          std::ifstream convertedFile(tempOutputPath, std::ios::binary);
+          std::ostringstream convertedContent;
+          convertedContent << convertedFile.rdbuf();
+          convertedFile.close();
 
-  // Endpoint to download files
-  CROW_ROUTE(app, "/download")
-      .methods(crow::HTTPMethod::GET)([](const crow::request &req) {
-        try {
-          // Extract the filename from query parameters
-          char *fileName = req.url_params.get("file");
-          if (!fileName) {
-            return crow::response(400, "Missing 'file' query parameter.");
-          }
+          // Clean up temporary files
+          std::filesystem::remove(tempInputPath);
+          std::filesystem::remove(tempOutputPath);
 
-          // Build the file path
-          std::string filePath = "./data/" + std::string(fileName);
-
-          // Check if the file exists
-          if (!std::filesystem::exists(filePath)) {
-            return crow::response(404, "File not found: " + filePath);
-          }
-
-          // Read the file content
-          std::ifstream inFile(filePath, std::ios::binary);
-          std::ostringstream fileContent;
-          fileContent << inFile.rdbuf();
-          inFile.close();
-
-          // Serve the file as a downloadable response
-          crow::response res(fileContent.str());
+          // Return the converted file directly
+          crow::response res(convertedContent.str());
           res.add_header("Content-Disposition",
-                         "attachment; filename=" + std::string(fileName));
+                         "attachment; filename=" + fileNameWithoutExtension +
+                             "." + std::string(fileType));
           res.add_header("Content-Type", "application/octet-stream");
           return res;
+
         } catch (const std::exception &e) {
+          std::cerr << "Exception occurred: " << e.what() << std::endl;
           return crow::response(500, "Unexpected error occurred: " +
                                          std::string(e.what()));
         }

--- a/api/api_handler.h
+++ b/api/api_handler.h
@@ -1,0 +1,17 @@
+#ifndef API_HANDLER_H
+#define API_HANDLER_H
+
+#include "converter.h"
+#include "fileformat.h"
+#include "utils.h"
+#include <converter.h>
+#include <crow.h>
+#include <filesystem> // For creating/checking directories
+#include <fstream>    // For file handling
+
+class APIHandler {
+public:
+  void startServer(int port);
+};
+
+#endif

--- a/api/api_main.cpp
+++ b/api/api_main.cpp
@@ -1,0 +1,9 @@
+#include "api_handler.h"
+
+int main() {
+  crow::SimpleApp app; // define your crow application
+
+  APIHandler apiHandler;
+
+  apiHandler.startServer(18080);
+}


### PR DESCRIPTION
### What

Created an REST API for filely that can be run with a docker container.

### How

- Added `crow` web framework for making the REST API
- Added the `/convert` route as a POST request where you have to put the following:
- form-data with a file and a key of `file`
- query param of `type` to specify the file type you want to convert to
- To run our actual docker instance you first must build ` docker build -t filely-server .`
- Then run the actual container ` docker run -p 18080:18080 filely-server` and the server will run on `http://localhost:18080`

### Why

Other teams can easily integrate our service by using our API which we could even deploy to a VPS